### PR TITLE
Fix typo in the package name in MainApplication import

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ include ':app'
 ```
 • in `MainApplication.java:`
 ```diff
-+ import com.mustansirzia.fused.FusedLocation;
++ import com.mustansirzia.fused.FusedLocationPackage;
     
     @Override
         protected List<ReactPackage> getPackages() {
           return Arrays.<ReactPackage>asList(
               ...
-+             new FusedLocation(),
++             new FusedLocationPackage(),
               ...
               new MainReactPackage()
           );


### PR DESCRIPTION
Hi!

The import and package name should be `FusedLocationPackage`.

Anyway, thank you for sharing this library! I was so frustrated with native support from navigator.geolocation :(. This is so much easier.