### PR TITLE
Add fusedLocationStatus event and fixes stopLocationUpdates

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,16 @@ async componentDidMount() {
             console.warn(error);
         });
         */
+       
+        /* Optional
+        this.statusSubscription = FusedLocation.on('fusedLocationStatus', status => {
+            /* status = {
+             availability: true 
+            }
+            */
+            console.log(status);
+        });
+        */
      }
 
 ...

--- a/main.js
+++ b/main.js
@@ -2,53 +2,53 @@
  * Created by M on 11/06/17. With ❤
  */
 
-import {NativeModules, DeviceEventEmitter, Platform} from 'react-native';
+import {NativeModules, DeviceEventEmitter, Platform} from 'react-native'
 
-const FusedLocation = NativeModules.FusedLocation;
-const eventNames = ['fusedLocation', 'fusedLocationError'];
+const FusedLocation = NativeModules.FusedLocation
+const eventNames = ['fusedLocation', 'fusedLocationError', 'fusedLocationStatus']
 
-const noIOS = () => console.warn('Fused location cannot be used for iOS.');
+const noIOS = () => console.warn('Fused location cannot be used for iOS.')
 
 const Dumb = {
-    getFusedLocation: noIOS,
-    startLocationUpdates: noIOS,
-    stopLocationUpdates: noIOS,
-    on: () => noIOS,
-    off: () => noIOS,
-    setLocationPriority: noIOS,
-    setLocationInterval: noIOS,
-    setFastestLocationInterval: noIOS,
-    setSmallestDisplacement: noIOS,
-    areProvidersAvailable: noIOS,
-};
+  getFusedLocation: noIOS,
+  startLocationUpdates: noIOS,
+  stopLocationUpdates: noIOS,
+  on: () => noIOS,
+  off: () => noIOS,
+  setLocationPriority: noIOS,
+  setLocationInterval: noIOS,
+  setFastestLocationInterval: noIOS,
+  setSmallestDisplacement: noIOS,
+  areProvidersAvailable: noIOS
+}
 
 const Location = Platform.OS === 'ios' ? Dumb : {
-    getFusedLocation: forceNewLocation => forceNewLocation ? FusedLocation.getFusedLocation(true) : FusedLocation.getFusedLocation(false),
-    startLocationUpdates: FusedLocation.startLocationUpdates,
-    stopLocationUpdates: FusedLocation.stopLocationUpdates,
-    on: (eventName, cb) => {
-        if (eventNames.indexOf(eventName) === -1) {
-            throw new Error('Event name has to be one of \'fusedLocation\' or \'fusedLocationError\'');
-        }
-        return {listener: DeviceEventEmitter.addListener(eventName, cb).listener, eventName};
-    },
-    off: subscription => DeviceEventEmitter.removeListener(subscription.eventName, subscription.listener),
-    setLocationPriority: priority => {
-        if (priority < 0 || priority > 3) {
-            throw new Error('Invalid priority set for fused api');
-        }
-        FusedLocation.setLocationPriority(priority);
-    },
-    setLocationInterval: FusedLocation.setLocationInterval,
-    setFastestLocationInterval: FusedLocation.setFastestLocationInterval,
-    setSmallestDisplacement: FusedLocation.setSmallestDisplacement,
-    areProvidersAvailable: FusedLocation.areProvidersAvailable,
-    Constants: {
-        HIGH_ACCURACY: 0,
-        BALANCED: 1,
-        LOW_POWER: 2,
-        NO_POWER: 3
+  getFusedLocation: forceNewLocation => forceNewLocation ? FusedLocation.getFusedLocation(true) : FusedLocation.getFusedLocation(false),
+  startLocationUpdates: FusedLocation.startLocationUpdates,
+  stopLocationUpdates: FusedLocation.stopLocationUpdates,
+  on: (eventName, cb) => {
+    if (eventNames.indexOf(eventName) === -1) {
+      throw new Error('Event name has to be one of \'fusedLocation\' or \'fusedLocationError\' or \'fusedLocationStatus\'')
     }
-};
+    return {listener: DeviceEventEmitter.addListener(eventName, cb).listener, eventName}
+  },
+  off: subscription => DeviceEventEmitter.removeListener(subscription.eventName, subscription.listener),
+  setLocationPriority: priority => {
+    if (priority < 0 || priority > 3) {
+      throw new Error('Invalid priority set for fused api')
+    }
+    FusedLocation.setLocationPriority(priority)
+  },
+  setLocationInterval: FusedLocation.setLocationInterval,
+  setFastestLocationInterval: FusedLocation.setFastestLocationInterval,
+  setSmallestDisplacement: FusedLocation.setSmallestDisplacement,
+  areProvidersAvailable: FusedLocation.areProvidersAvailable,
+  Constants: {
+    HIGH_ACCURACY: 0,
+    BALANCED: 1,
+    LOW_POWER: 2,
+    NO_POWER: 3
+  }
+}
 
-export default Location;
+export default Location


### PR DESCRIPTION
Added fusedLocationStatus which should always be triggered after startLocationUpdates (to avoid scenario where it is not called - see #14). Also nice as it triggers an event on a OS-level change (user disables GPS/airplane mode/whatever...event is triggered).

The other thing is a fix for stopLocationUpdates. Because no disconnect happened on the API client the GPS still remained active (in the case of selecting the HIGH_ACCURACY level).

Also, my linter (https://github.com/standard/standard) cleaned up the main.js file a bit. I can revert that if you'd like.