### PR TITLE
fix: areProvidersAvailable() method is returning a proper value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules
 npm-debug.log
 .idea
+android/android.iml
+android/build/*
+android/gradle/*
+android/.gradle/*
+android/gradlew
+android/gradlew.bat
+android/local.properties

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Add this to your `AndroidManifest.xml`:
 | `stopLocationUpdates` | Nil | Nil | Stop receiving location updates. Call this to stop listening to device's location updates.
 | `on` | `eventName, callback` | `Subscription` | Subscribe to an event. The callback with `Location` updates is eventName is `fusedLocation`. <br /> Call this after you call `startLocationUpdates`
 | `off` | `Subscription` | Nil | Unsubscribe from the corresponding subscription.
-| `areProvidersAvailable` | Nil | Boolean | Returns true if location providers are currently available on the device. False otherwise.
+| `areProvidersAvailable` | Nil | `Promise[Boolean]` | Returns a promise that will always resolve to a boolean value. The resolved value reflects the providers' availability; true when location providers are available and false otherwise.
 
 ### Configuration.
 #### `setLocationPriority(priority)` <br />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,11 @@ android {
     }
 }
 
+
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-location:+'

--- a/android/src/main/java/com/mustansirzia/fused/FusedLocationModule.java
+++ b/android/src/main/java/com/mustansirzia/fused/FusedLocationModule.java
@@ -207,7 +207,11 @@ public class FusedLocationModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public boolean areProvidersAvailable() {
+    public void areProvidersAvailable(final Promise promise) {
+        promise.resolve(areProvidersAvailable());
+    }
+
+    private boolean areProvidersAvailable() {
         LocationManager lm = (LocationManager) getReactApplicationContext().getSystemService(Context.LOCATION_SERVICE);
         boolean gps_enabled = false;
         try {


### PR DESCRIPTION
Before this PR the `areProvidersAvailable()` method was always returning `undefined`. This was happening because React Native modules are async by nature (thanks to the bridge) as specified in the [official docs](https://facebook.github.io/react-native/docs/native-modules-android.html):

> To expose a method to JavaScript a Java method must be annotated using @ReactMethod. The return type of bridge methods is always void. React Native bridge is asynchronous, so the only way to pass a result to JavaScript is by using callbacks or emitting events (see below).

