### PR TITLE
fix: async management improved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 node_modules
 npm-debug.log
 .idea
+android/android.iml
+android/build/*
+android/gradle/*
+android/.gradle/*
+android/gradlew
+android/gradlew.bat
+android/local.properties

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ Add this to your `AndroidManifest.xml`:
 ### API.
 | Function | Arguments | Returns | Note |
 |:---|:---:|:---:|:------|
-| `getFusedLocation` | `forceNewLocation` | `Location` | Call this once to get `Location`. Pass optional boolean `forceNewLocation` to get new location update. Otherwise return the last known location. Returns a promise.
-| `startLocationUpdates` | Nil | Nil | Call this to start receiving location updates. <br /> **<b>Note</b>: You still need to subscribe to `fusedLocation` event. <br /> So, you need to call this before you call `FusedLocation.on`.
-| `stopLocationUpdates` | Nil | Nil | Stop receiving location updates. Call this to stop listening to device's location updates.
+| `getFusedLocation` | `forceNewLocation` | `Promise[Location]` | Call this once to get `Location`. Pass optional boolean `forceNewLocation` to get new location update. Otherwise return the last known location. Returns a promise.
+| `startLocationUpdates` | Nil | `Promise[Nil]` | Call this to start receiving location updates. The function returns a promise that will resolve after the bootstrap of the Fused provider is done. <br /> **<b>Note</b>: You still need to subscribe to `fusedLocation` event. <br /> So, you need to call this before you call `FusedLocation.on`.
+| `stopLocationUpdates` | Nil | `Promise[Boolean]` | Stop receiving location updates. Call this to stop listening to device's location updates. The function returns a promise that will resolve to a boolean reflecting if the updates were indeed stoped or not (because they were already stopped).
 | `on` | `eventName, callback` | `Subscription` | Subscribe to an event. The callback with `Location` updates is eventName is `fusedLocation`. <br /> Call this after you call `startLocationUpdates`
 | `off` | `Subscription` | Nil | Unsubscribe from the corresponding subscription.
 | `areProvidersAvailable` | Nil | Boolean | Returns true if location providers are currently available on the device. False otherwise.

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,11 @@ android {
     }
 }
 
+
+repositories {
+    mavenCentral()
+}
+
 dependencies {
     compile 'com.facebook.react:react-native:+'
     compile 'com.google.android.gms:play-services-location:+'

--- a/android/src/main/java/com/mustansirzia/fused/FusedLocationModule.java
+++ b/android/src/main/java/com/mustansirzia/fused/FusedLocationModule.java
@@ -42,6 +42,9 @@ public class FusedLocationModule extends ReactContextBaseJavaModule {
     private final int PLAY_SERVICES_RESOLUTION_REQUEST = 2404;
     private final String NATIVE_EVENT = "fusedLocation";
     private final String NATIVE_ERROR = "fusedLocationError";
+    private final String ERROR_PLAY_SERVICES_NOT_FOUND = "Play services not found.";
+    private final String ERROR_UNAUTHORIZED = "Appropriate permissions not given.";
+    private final String ERROR_NO_LOCATION_PROVIDER = "No location provider found.";
     private int mLocationInterval = 15000;
     private int mLocationPriority = LocationRequest.PRIORITY_BALANCED_POWER_ACCURACY;
     private int mLocationFastestInterval = 10000;
@@ -96,15 +99,15 @@ public class FusedLocationModule extends ReactContextBaseJavaModule {
     public void getFusedLocation(boolean forceNewLocation, final Promise promise) {
         try {
             if (!areProvidersAvailable()) {
-                promise.reject(TAG, "No location provider found.");
+                promise.reject(TAG, ERROR_NO_LOCATION_PROVIDER);
                 return;
             }
             if (!checkForPlayServices()) {
-                promise.reject(TAG, "Install Google Play Services First and Try Again.");
+                promise.reject(TAG, ERROR_PLAY_SERVICES_NOT_FOUND);
                 return;
             }
             if (ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-                promise.reject(TAG, "Appropriate permissions not given.");
+                promise.reject(TAG, ERROR_UNAUTHORIZED);
                 return;
             }
             final GoogleApiClient googleApiClient;
@@ -149,28 +152,31 @@ public class FusedLocationModule extends ReactContextBaseJavaModule {
 
     @SuppressWarnings("All")
     @ReactMethod
-    public void startLocationUpdates() {
+    public void startLocationUpdates(final Promise promise) {
         try {
             if (!checkForPlayServices()) {
                 WritableMap params = new WritableNativeMap();
-                params.putString("error", "Play services not found.");
+                params.putString("error", ERROR_PLAY_SERVICES_NOT_FOUND);
                 sendEvent(getReactApplicationContext(), NATIVE_ERROR, params);
+                promise.reject(TAG, ERROR_PLAY_SERVICES_NOT_FOUND);
                 return;
             }
             if (ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED && ActivityCompat.checkSelfPermission(getReactApplicationContext(), Manifest.permission.ACCESS_COARSE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
                 WritableMap params = new WritableNativeMap();
-                params.putString("error", "Appropriate permissions not given.");
+                params.putString("error", ERROR_UNAUTHORIZED);
                 sendEvent(getReactApplicationContext(), NATIVE_ERROR, params);
+                promise.reject(TAG, ERROR_UNAUTHORIZED);
                 return;
             }
             if (!areProvidersAvailable()) {
                 WritableMap params = new WritableNativeMap();
-                params.putString("error", "No location provider found.");
+                params.putString("error", ERROR_NO_LOCATION_PROVIDER);
                 sendEvent(getReactApplicationContext(), NATIVE_ERROR, params);
+                promise.reject(TAG, ERROR_NO_LOCATION_PROVIDER);
                 return;
             }
             LocationRequest request = buildLR();
-            Log.e("request", request.getPriority() + "");
+            Log.d("request", request.getPriority() + "");
             mGoogleApiClient = new GoogleApiClient.Builder(getReactApplicationContext())
                     .addApi(LocationServices.API)
                     .build();
@@ -182,27 +188,35 @@ public class FusedLocationModule extends ReactContextBaseJavaModule {
                 }
             };
             LocationServices.FusedLocationApi.requestLocationUpdates(mGoogleApiClient, request, mLocationListener);
+            promise.resolve(null);
         } catch (Exception ex) {
             Log.e(TAG, "Native Location Module ERR - " + ex.toString());
             WritableMap params = new WritableNativeMap();
             params.putString("error", "Native Location Module ERR - " + ex.toString());
             sendEvent(getReactApplicationContext(), NATIVE_ERROR, params);
+            promise.reject(TAG, ex);
         }
     }
 
     @ReactMethod
-    public void stopLocationUpdates() {
-        if (mGoogleApiClient != null && mLocationListener != null) {
+    public void stopLocationUpdates(final Promise promise) {
+        if (mGoogleApiClient != null && mLocationListener != null && mGoogleApiClient.isConnected()) {
             PendingResult<Status> pendingResult = LocationServices.FusedLocationApi.removeLocationUpdates(mGoogleApiClient, mLocationListener);
             pendingResult.setResultCallback(new ResultCallback<Status>() {
                 @Override
                 public void onResult(@NonNull Status status) {
+                    mGoogleApiClient.disconnect();
                     if (!status.isSuccess()) {
                         Log.e(TAG, "Could not remove location updates.");
+                        promise.reject(TAG, String.valueOf(status.getStatusCode()));
+                    } else {
+                        promise.resolve(true);
                     }
-                    mGoogleApiClient.disconnect();
+
                 }
             });
+        } else {
+            promise.resolve(false);
         }
     }
 
@@ -272,7 +286,7 @@ public class FusedLocationModule extends ReactContextBaseJavaModule {
                     .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                     .emit(eventName, params);
         } else {
-            Log.i(TAG, "Waiting for Catalyst Instance...");
+            Log.d(TAG, "Waiting for Catalyst Instance...");
         }
     }
 }


### PR DESCRIPTION
1) The main purpose of this PR is to fix the crash produced by the following sequence of calls:
```
...
FusedLocation.startLocationUpdates();
FusedLocation.stopLocationUpdates();
FusedLocation.stopLocationUpdates();
...
```
While strange this is a possible scenario, specially when start/stop is tied to external events that are "randomly triggered". On those scenarios an _un-catcheable async exception_ was being thrown: `java.lang.IllegalStateException: GoogleApiClient is not connected yet.`.
The good thing is that making the library more robust regarding this kind of scenarios is pretty easy; just add a guard on the `stopLocationUpdates` method:
`if (mGoogleApiClient != null && mLocationListener != null && mGoogleApiClient.isConnected())`

2) On the other hand, both `startLocationUpdates` and `stopLocationUpdates` are async (because of React Native nature in the first place) so I figured it would be nice (at least for my project :P) to know when those calls are competed. Because of that I made both methods to return a promise.

3) Finally I used the opportunity to cleanup the project a little bit.