### PR TITLE
Receive new points when GPS is turned on with the App open

### DIFF
--- a/android/src/main/java/com/mustansirzia/fused/FusedLocationModule.java
+++ b/android/src/main/java/com/mustansirzia/fused/FusedLocationModule.java
@@ -172,8 +172,9 @@ public class FusedLocationModule extends ReactContextBaseJavaModule {
                 WritableMap params = new WritableNativeMap();
                 params.putString("error", ERROR_NO_LOCATION_PROVIDER);
                 sendEvent(getReactApplicationContext(), NATIVE_ERROR, params);
-                promise.reject(TAG, ERROR_NO_LOCATION_PROVIDER);
-                return;
+                // Allow the App to still register the location updates so that it can send new locations if the user turns on the GPS through the notification bar
+                // promise.reject(TAG, ERROR_NO_LOCATION_PROVIDER);
+                // return;
             }
             LocationRequest request = buildLR();
             Log.d("request", request.getPriority() + "");


### PR DESCRIPTION
It seems that the `startLocationUpdates` was actually not subscribing the location updates if there was currently no provider. Given that, if the user turns on the GPS using the notification bar on Android, the App would never receive new GPS points.

By removing the return and the promise.reject but keeping the rest, we are still notified about no providers on fusedLocationError event and then, when the user turns GPS on through the notification bar, the App will start receiving GPS positions without the need to recall `startLocationUpdates`