### PR TITLE
Allow  googlePlayServicesVersion to be updated from outside

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,6 +10,8 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def DEFAULT_GOOGLE_PLAY_SERVICES_VERSION    = "+"
+
 def safeExtGet(prop, fallback) {
   rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
@@ -35,6 +37,8 @@ repositories {
 }
 
 dependencies {
+    def googlePlayServicesVersion = project.hasProperty('googlePlayServicesVersion') ? project.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
+
     compile 'com.facebook.react:react-native:+'
-    compile 'com.google.android.gms:play-services-location:+'
+    compile 'com.google.android.gms:play-services-location:$googlePlayServicesVersion'
 }


### PR DESCRIPTION
Having only '+' force the latests library avalaible, it can break when google update ( it did break when they released android x play services)